### PR TITLE
Fallback to parsing clearance as nato if base64 parse fails

### DIFF
--- a/cxx/clearance.cc
+++ b/cxx/clearance.cc
@@ -79,7 +79,13 @@ JNIEXPORT void JNICALL Java_com_surevine_spiffing_Clearance_init
         Spiffing::Clearance * clr = new Spiffing::Clearance(clrstr, Spiffing::Format::BER);
         setHandle(jenv, jobj, clr);
     } catch (std::runtime_error & e) {
-        SpiffingJNI::throwJava(jenv, e);
+        try {
+            const char *xmlString = jenv->GetStringUTFChars(jbase64, nullptr);
+            Spiffing::Clearance * clr = new Spiffing::Clearance(xmlString, Spiffing::Format::XML);
+            setHandle(jenv, jobj, clr);
+        } catch (std::runtime_error & e) {
+            SpiffingJNI::throwJava(jenv, e);
+        }
     }
 }
 


### PR DESCRIPTION
I doubt you want to merge this, but it's the only way I could get it to work (couldn't figure out how to change method signatures in JNI. Simply falls back to attempting to parse a label as nato if a base64 decode fails - pretty ugly I know.

Required for: https://github.com/surevine/spiffing-openfire/pull/1